### PR TITLE
feat: allow JSON base64 padding

### DIFF
--- a/CBOR/PeterO/Cbor/CBORJson.cs
+++ b/CBOR/PeterO/Cbor/CBORJson.cs
@@ -511,7 +511,8 @@ namespace PeterO.Cbor {
 
     internal static void WriteJSONToInternal(
       CBORObject obj,
-      StringOutput writer) {
+      StringOutput writer,
+      JSONOptions options) {
       int type = obj.ItemType;
       object thisItem = obj.ThisItem;
       switch (type) {
@@ -610,7 +611,7 @@ namespace PeterO.Cbor {
                 byteArray,
                 0,
                 byteArray.Length,
-                false);
+                options.Base64Padding);
             } else if (obj.HasTag(23)) {
               // Write as base16
               for (int i = 0; i < byteArray.Length; ++i) {
@@ -623,7 +624,7 @@ namespace PeterO.Cbor {
                 byteArray,
                 0,
                 byteArray.Length,
-                false);
+                options.Base64Padding);
             }
             writer.WriteCodePoint((int)'\"');
             break;
@@ -646,7 +647,7 @@ namespace PeterO.Cbor {
               if (!first) {
                 writer.WriteCodePoint((int)',');
               }
-              WriteJSONToInternal(i, writer);
+              WriteJSONToInternal(i, writer, options);
               first = false;
             }
             writer.WriteCodePoint((int)']');
@@ -686,7 +687,7 @@ namespace PeterO.Cbor {
                 WriteJSONStringUnquoted((string)key.ThisItem, writer);
                 writer.WriteCodePoint((int)'\"');
                 writer.WriteCodePoint((int)':');
-                WriteJSONToInternal(value, writer);
+                WriteJSONToInternal(value, writer, options);
                 first = false;
               }
               writer.WriteCodePoint((int)'}');
@@ -716,7 +717,7 @@ namespace PeterO.Cbor {
                 WriteJSONStringUnquoted((string)key, writer);
                 writer.WriteCodePoint((int)'\"');
                 writer.WriteCodePoint((int)':');
-                WriteJSONToInternal(value, writer);
+                WriteJSONToInternal(value, writer, options);
                 first = false;
               }
               writer.WriteCodePoint((int)'}');

--- a/CBOR/PeterO/Cbor/CBORObject.cs
+++ b/CBOR/PeterO/Cbor/CBORObject.cs
@@ -2707,6 +2707,10 @@ mapValue = mapValue ?? CBORObject.FromObject(valueOb);
     /// <include file='../../docs.xml'
     /// path='docs/doc[@name="M:PeterO.Cbor.CBORObject.ToJSONString"]/*'/>
     public string ToJSONString() {
+      return ToJSONString(JSONOptions.Default);
+    }
+    
+    public string ToJSONString(JSONOptions options) { 
       int type = this.ItemType;
       switch (type) {
         case CBORObjectTypeSimpleValue: {
@@ -2719,7 +2723,7 @@ mapValue = mapValue ?? CBORObject.FromObject(valueOb);
           {
             var sb = new StringBuilder();
             try {
-              CBORJson.WriteJSONToInternal(this, new StringOutput(sb));
+              CBORJson.WriteJSONToInternal(this, new StringOutput(sb), options);
             } catch (IOException ex) {
               // This is truly exceptional
               throw new InvalidOperationException("Internal error", ex);
@@ -2921,7 +2925,14 @@ sb = sb ?? (new StringBuilder());
       if (outputStream == null) {
         throw new ArgumentNullException("outputStream");
       }
-      CBORJson.WriteJSONToInternal(this, new StringOutput(outputStream));
+      CBORJson.WriteJSONToInternal(this, new StringOutput(outputStream), JSONOptions.Default);
+    }
+
+    public void WriteJSONTo(Stream outputStream, JSONOptions options) {
+      if (outputStream == null) {
+        throw new ArgumentNullException("outputStream");
+      }
+      CBORJson.WriteJSONToInternal(this, new StringOutput(outputStream), options);
     }
 
     /// <include file='../../docs.xml'

--- a/CBOR/PeterO/Cbor/JSONOptions.cs
+++ b/CBOR/PeterO/Cbor/JSONOptions.cs
@@ -1,0 +1,29 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace PeterO.Cbor
+{
+    /// <summary>
+    ///   CBOR to JSON onversion options.
+    /// </summary>
+    /// <seealso cref="CBORObject.ToJSONString"/>
+    public class JSONOptions
+    {
+        /// <summary>
+        ///   The default options for converting to JSON.
+        /// </summary>
+        public readonly static JSONOptions Default = new JSONOptions();
+
+        /// <summary>
+        ///   Pad any base-64 encoding.
+        /// </summary>
+        /// <value>
+        ///   The default is <b>false</b>, no padding.
+        /// </value>
+        /// <remarks>
+        ///   The padding character is '='.
+        /// </remarks>
+        public bool Base64Padding { get; set; }
+    }
+}

--- a/CBORTest/CBORObjectTest.cs
+++ b/CBORTest/CBORObjectTest.cs
@@ -3950,6 +3950,59 @@ cbor = CBORObject.NewArray();
 cbor.Add(CBORObject.FromObjectAndTag(b64bytes, 22));
 TestSucceedingJSON(cbor.ToJSONString());
     }
+   
+    [Test]
+    public void TestToJSONString_ByteArray_Padding()
+    {
+      CBORObject o;
+      var options = new JSONOptions
+      {
+          Base64Padding = true
+      };
+      o = CBORObject.FromObjectAndTag(
+        new byte[] { 0x9a, 0xd6, 0xf0, 0xe8 }, 22);
+      {
+        string stringTemp = o.ToJSONString(options);
+        Assert.AreEqual(
+        "\"mtbw6A==\"",
+        stringTemp);
+      }
+      o = CBORObject.FromObject(new byte[] { 0x9a, 0xd6, 0xf0, 0xe8 });
+      {
+        string stringTemp = o.ToJSONString(options);
+        Assert.AreEqual(
+        "\"mtbw6A==\"",
+        stringTemp);
+      }
+      o = CBORObject.FromObjectAndTag(
+        new byte[] { 0x9a, 0xd6, 0xf0, 0xe8 },
+        23);
+      {
+        string stringTemp = o.ToJSONString(options);
+        Assert.AreEqual(
+        "\"9AD6F0E8\"",
+        stringTemp);
+      }
+      o = CBORObject.FromObject(new byte[] { 0x9a, 0xd6, 0xff, 0xe8 });
+      // Encode with Base64URL by default
+      {
+        string stringTemp = o.ToJSONString(options);
+        Assert.AreEqual(
+        "\"mtb_6A==\"",
+        stringTemp);
+      }
+      o = CBORObject.FromObjectAndTag(
+        new byte[] { 0x9a, 0xd6, 0xff, 0xe8 },
+        22);
+      // Encode with Base64
+      {
+        string stringTemp = o.ToJSONString(options);
+        Assert.AreEqual(
+        "\"mtb/6A==\"",
+        stringTemp);
+      }
+    }
+
     [Test]
     public void TestToString() {
       {


### PR DESCRIPTION
See https://github.com/peteroupc/CBOR/issues/14

- Defines` JSONOptions`
- Overload `CBORObject.ToJSONString` and `CBORObject.WriteJSONTo` to accept `JSONOptions`
- Use base64 padding if specified