### PR TITLE
feat: Controlling property name generation

### DIFF
--- a/CBOR/PeterO/Cbor/POCOOptions.cs
+++ b/CBOR/PeterO/Cbor/POCOOptions.cs
@@ -1,0 +1,25 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace PeterO.Cbor
+{
+    /// <summary>
+    ///   Options for converting a plain old c# object to a <see cref="CBORObject"/>.
+    /// </summary>
+    public static class POCOOptions
+    {
+        /// <summary>
+        ///   Remove leading "Is" from a property name.
+        /// </summary>
+        /// <value>
+        ///   The default is <b>true</b>.
+        /// </value>
+        public static bool RemoveIsPrefix { get; set; } = true;
+
+        /// <summary>
+        ///   Use camelCase for the property name.
+        /// </summary>
+        public static bool UseCamelCase { get; set; } = true;
+    }
+}

--- a/CBOR/PeterO/Cbor/PropertyMap.cs
+++ b/CBOR/PeterO/Cbor/PropertyMap.cs
@@ -106,7 +106,7 @@ namespace PeterO.Cbor {
             pd.Name = pi.Name;
             // Convert 'IsXYZ' to 'XYZ'
             if (pd.Name.Length >= 3 && pd.Name[0] == 'I' && pd.Name[1] == 's' &&
-                pd.Name[2] >= 'A' && pd.Name[2] == 'Z') {
+                pd.Name[2] >= 'A' && pd.Name[2] <= 'Z') {
               pd.Name = pd.Name.Substring(2);
             }
             // Convert to camel case

--- a/CBOR/PeterO/Cbor/PropertyMap.cs
+++ b/CBOR/PeterO/Cbor/PropertyMap.cs
@@ -105,12 +105,12 @@ namespace PeterO.Cbor {
             PropertyData pd = new PropertyMap.PropertyData();
             pd.Name = pi.Name;
             // Convert 'IsXYZ' to 'XYZ'
-            if (pd.Name.Length >= 3 && pd.Name[0] == 'I' && pd.Name[1] == 's' &&
+            if (POCOOptions.RemoveIsPrefix && pd.Name.Length >= 3 && pd.Name[0] == 'I' && pd.Name[1] == 's' &&
                 pd.Name[2] >= 'A' && pd.Name[2] <= 'Z') {
               pd.Name = pd.Name.Substring(2);
             }
             // Convert to camel case
-            if (pd.Name[0] >= 'A' && pd.Name[0] <= 'Z') {
+            if (POCOOptions.UseCamelCase && pd.Name[0] >= 'A' && pd.Name[0] <= 'Z') {
               var sb = new System.Text.StringBuilder();
               sb.Append((char)(pd.Name[0] + 0x20));
               sb.Append(pd.Name.Substring(1));

--- a/CBORTest/CBORObjectTest.cs
+++ b/CBORTest/CBORObjectTest.cs
@@ -4614,7 +4614,19 @@ TestSucceedingJSON(cbor.ToJSONString());
   CBORObject.FromObject(0),
   CBORObject.Zero);
     }
-
+    
+     class Poco
+     {
+        public bool IsSomething { get; set; }
+        public int Value { get; set; }
+     } 
+     [Test]
+     public void TestFromPoco()
+     {
+         var cbor = CBORObject.FromObject(new Poco());
+         Assert.IsTrue(cbor.ContainsKey("value"));
+         Assert.IsTrue(cbor.ContainsKey("something"));
+     }
     internal static void CompareDecimals(CBORObject o1, CBORObject o2) {
       int cmpDecFrac = TestCommon.CompareTestReciprocal(
         o1.AsEDecimal(),

--- a/CBORTest/CBORObjectTest.cs
+++ b/CBORTest/CBORObjectTest.cs
@@ -4615,6 +4615,11 @@ TestSucceedingJSON(cbor.ToJSONString());
   CBORObject.Zero);
     }
     
+     class poco
+     {
+        public bool IsSomething { get; set; }
+        public int Value { get; set; }
+     } 
      class Poco
      {
         public bool IsSomething { get; set; }
@@ -4623,10 +4628,24 @@ TestSucceedingJSON(cbor.ToJSONString());
      [Test]
      public void TestFromPoco()
      {
-         var cbor = CBORObject.FromObject(new Poco());
-         Assert.IsTrue(cbor.ContainsKey("value"));
-         Assert.IsTrue(cbor.ContainsKey("something"));
-     }
+        var cbor = CBORObject.FromObject(new poco());
+        Assert.IsTrue(cbor.ContainsKey("value"));
+        Assert.IsTrue(cbor.ContainsKey("something"));
+
+        POCOOptions.RemoveIsPrefix = false;
+        POCOOptions.UseCamelCase = false;
+        try
+        {
+            var cbor1 = CBORObject.FromObject(new Poco());
+            Assert.IsTrue(cbor1.ContainsKey("Value"));
+            Assert.IsTrue(cbor1.ContainsKey("IsSomething"));
+        }
+        finally
+        {
+            POCOOptions.RemoveIsPrefix = true;
+            POCOOptions.UseCamelCase = true;
+        }
+        }
     internal static void CompareDecimals(CBORObject o1, CBORObject o2) {
       int cmpDecFrac = TestCommon.CompareTestReciprocal(
         o1.AsEDecimal(),


### PR DESCRIPTION
PR for #15 

- fix removing 'Is' from property name
- add POCOOptions to control property name generation