### PR TITLE
Use dictionary TryGetValue() instead of ContainsKey()+indexer

### DIFF
--- a/CBOR.sln
+++ b/CBOR.sln
@@ -1,52 +1,36 @@
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 2012
-VisualStudioVersion = 14.0.23107.0
+# Visual Studio Version 17
+VisualStudioVersion = 17.5.33516.290
 MinimumVisualStudioVersion = 10.0.40219.1
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CBORDocs2", "CBORDocs2\CBORDocs2.csproj", "{B38659A7-A3DB-4CD1-8DFF-641B579E5092}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "CBORDocs2", "CBORDocs2\CBORDocs2.csproj", "{B38659A7-A3DB-4CD1-8DFF-641B579E5092}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CBOR", "CBOR\CBOR.csproj", "{44A061F7-B6A8-4FBD-993E-3746E8C42D6B}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "CBOR", "CBOR\CBOR.csproj", "{44A061F7-B6A8-4FBD-993E-3746E8C42D6B}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CBORTest", "CBORTest\CBORTest.csproj", "{8FE63143-541E-448D-8337-A98D1FA51541}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "CBORTest", "CBORTest\CBORTest.csproj", "{8FE63143-541E-448D-8337-A98D1FA51541}"
 EndProject
 Global
-  GlobalSection(SolutionConfigurationPlatforms) = preSolution
-    Debug|Any CPU = Debug|Any CPU
-    Release|Any CPU = Release|Any CPU
-  EndGlobalSection
-  GlobalSection(ProjectConfigurationPlatforms) = postSolution
-    {B38659A7-A3DB-4CD1-8DFF-641B579E5092}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-    {B38659A7-A3DB-4CD1-8DFF-641B579E5092}.Debug|Any CPU.Build.0 = Debug|Any CPU
-    {B38659A7-A3DB-4CD1-8DFF-641B579E5092}.Release|Any CPU.ActiveCfg = Release|Any CPU
-    {B38659A7-A3DB-4CD1-8DFF-641B579E5092}.Release|Any CPU.Build.0 = Release|Any CPU
-    {44A061F7-B6A8-4FBD-993E-3746E8C42D6B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-    {44A061F7-B6A8-4FBD-993E-3746E8C42D6B}.Debug|Any CPU.Build.0 = Debug|Any CPU
-    {44A061F7-B6A8-4FBD-993E-3746E8C42D6B}.Release|Any CPU.ActiveCfg = Release|Any CPU
-    {44A061F7-B6A8-4FBD-993E-3746E8C42D6B}.Release|Any CPU.Build.0 = Release|Any CPU
-    {8FE63143-541E-448D-8337-A98D1FA51541}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-    {8FE63143-541E-448D-8337-A98D1FA51541}.Debug|Any CPU.Build.0 = Debug|Any CPU
-    {8FE63143-541E-448D-8337-A98D1FA51541}.Release|Any CPU.ActiveCfg = Release|Any CPU
-    {8FE63143-541E-448D-8337-A98D1FA51541}.Release|Any CPU.Build.0 = Release|Any CPU
-    {B4719819-FE90-4A02-A71B-0169583B4752}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-    {C53FD486-9486-43EA-9257-FDD713F57050}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-    {C53FD486-9486-43EA-9257-FDD713F57050}.Debug|Any CPU.Build.0 = Debug|Any CPU
-    {C53FD486-9486-43EA-9257-FDD713F57050}.Release|Any CPU.ActiveCfg = Release|Any CPU
-    {C53FD486-9486-43EA-9257-FDD713F57050}.Release|Any CPU.Build.0 = Release|Any CPU
-    {C53FD486-9486-43EA-9257-FDD713F57050}.ReleaseNet40|Any CPU.ActiveCfg = Debug|Any CPU
-    {C53FD486-9486-43EA-9257-FDD713F57050}.ReleaseNet40|Any CPU.Build.0 = Debug|Any CPU
-    {F25D228F-FE3D-4BE8-8AEB-DCA3700DFED5}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-    {F25D228F-FE3D-4BE8-8AEB-DCA3700DFED5}.Debug|Any CPU.Build.0 = Debug|Any CPU
-    {F25D228F-FE3D-4BE8-8AEB-DCA3700DFED5}.Release|Any CPU.ActiveCfg = Release|Any CPU
-    {F25D228F-FE3D-4BE8-8AEB-DCA3700DFED5}.Release|Any CPU.Build.0 = Release|Any CPU
-    {857523E5-B17E-412E-B890-9DCDFCFB6266}.Release|Any CPU.ActiveCfg = Debug|Any CPU
-    {857523E5-B17E-412E-B890-9DCDFCFB6266}.Release|Any CPU.Build.0 = Debug|Any CPU
-    {857523E5-B17E-412E-B890-9DCDFCFB6266}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-    {857523E5-B17E-412E-B890-9DCDFCFB6266}.Debug|Any CPU.Build.0 = Debug|Any CPU
-    {1A835385-8CA8-4552-BB37-049B9CAD2B3A}.Release|Any CPU.ActiveCfg = Debug|Any CPU
-    {1A835385-8CA8-4552-BB37-049B9CAD2B3A}.Release|Any CPU.Build.0 = Debug|Any CPU
-    {1A835385-8CA8-4552-BB37-049B9CAD2B3A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-    {1A835385-8CA8-4552-BB37-049B9CAD2B3A}.Debug|Any CPU.Build.0 = Debug|Any CPU
-  EndGlobalSection
-  GlobalSection(SolutionProperties) = preSolution
-    HideSolutionNode = FALSE
-  EndGlobalSection
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{B38659A7-A3DB-4CD1-8DFF-641B579E5092}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{B38659A7-A3DB-4CD1-8DFF-641B579E5092}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{B38659A7-A3DB-4CD1-8DFF-641B579E5092}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{B38659A7-A3DB-4CD1-8DFF-641B579E5092}.Release|Any CPU.Build.0 = Release|Any CPU
+		{44A061F7-B6A8-4FBD-993E-3746E8C42D6B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{44A061F7-B6A8-4FBD-993E-3746E8C42D6B}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{44A061F7-B6A8-4FBD-993E-3746E8C42D6B}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{44A061F7-B6A8-4FBD-993E-3746E8C42D6B}.Release|Any CPU.Build.0 = Release|Any CPU
+		{8FE63143-541E-448D-8337-A98D1FA51541}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{8FE63143-541E-448D-8337-A98D1FA51541}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{8FE63143-541E-448D-8337-A98D1FA51541}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{8FE63143-541E-448D-8337-A98D1FA51541}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {FDBC18D9-2C43-41BF-A01B-7F87F9C1AEA2}
+	EndGlobalSection
 EndGlobal

--- a/CBOR/PeterO/Cbor/CBORObject.cs
+++ b/CBOR/PeterO/Cbor/CBORObject.cs
@@ -639,7 +639,7 @@ namespace PeterO.Cbor {
           CBORObject key = CBORObject.FromObject(index);
           // TODO: In next major version, consider throwing an exception
           // instead if key does not exist.
-          return (!map.ContainsKey(key)) ? null : map[key];
+          return (!map.TryGetValue(key, out CBORObject cborObj)) ? null : cborObj;
         }
         throw new InvalidOperationException("Not an array or map");
       }
@@ -743,7 +743,7 @@ namespace PeterO.Cbor {
         }
         if (this.Type == CBORType.Map) {
           IDictionary<CBORObject, CBORObject> map = this.AsMap();
-          return (!map.ContainsKey(key)) ? null : map[key];
+          return (!map.TryGetValue(key, out CBORObject cborObj)) ? null : cborObj;
         }
         if (this.Type == CBORType.Array) {
           if (!key.IsNumber || !key.AsNumber().IsInteger()) {
@@ -6235,12 +6235,7 @@ CBORObjectTypeTextStringAscii)) {
       }
       if (this.Type == CBORType.Map) {
         IDictionary<CBORObject, CBORObject> dict = this.AsMap();
-        bool hasKey = dict.ContainsKey(obj);
-        if (hasKey) {
-          dict.Remove(obj);
-          return true;
-        }
-        return false;
+        return dict.Remove(obj);
       }
       if (this.Type == CBORType.Array) {
         IList<CBORObject> list = this.AsList();
@@ -6287,11 +6282,7 @@ CBORObjectTypeTextStringAscii)) {
           mapValue = mapValue ?? CBORObject.FromObject(valueOb);
         }
         IDictionary<CBORObject, CBORObject> map = this.AsMap();
-        if (map.ContainsKey(mapKey)) {
-          map[mapKey] = mapValue;
-        } else {
-          map.Add(mapKey, mapValue);
-        }
+        map[mapKey] = mapValue;
       } else if (this.Type == CBORType.Array) {
         if (key is int) {
           IList<CBORObject> list = this.AsList();

--- a/CBOR/PeterO/Cbor/CBORReader.cs
+++ b/CBOR/PeterO/Cbor/CBORReader.cs
@@ -267,19 +267,19 @@ count);
       int t = count;
       int tpos = offset;
       while (t > 0) {
-              int rcount = stream.Read(bytes, tpos, t);
-              if (rcount <= 0) {
-                 throw new CBORException("Premature end of data");
-              }
-              if (rcount > t) {
-                 throw new CBORException("Internal error");
-              }
-              tpos = checked(tpos + rcount);
-              t = checked(t - rcount);
-           }
-           if (t != 0) {
-             throw new CBORException("Internal error");
-           }
+        int rcount = stream.Read(bytes, tpos, t);
+        if (rcount <= 0) {
+           throw new CBORException("Premature end of data");
+        }
+        if (rcount > t) {
+           throw new CBORException("Internal error");
+        }
+        tpos = checked(tpos + rcount);
+        t = checked(t - rcount);
+      }
+      if (t != 0) {
+        throw new CBORException("Internal error");
+      }
     }
 
     public CBORObject ReadForFirstByte(int firstbyte) {

--- a/CBOR/PeterO/Cbor/CBORTypeMapper.cs
+++ b/CBOR/PeterO/Cbor/CBORTypeMapper.cs
@@ -69,10 +69,7 @@ namespace PeterO.Cbor {
     internal object ConvertBackWithConverter(
       CBORObject cbor,
       Type type) {
-      ConverterInfo convinfo = null;
-      if (this.converters.ContainsKey(type)) {
-        convinfo = this.converters[type];
-      } else {
+      if (!this.converters.TryGetValue(type, out ConverterInfo convinfo)) {
         return null;
       }
       if (convinfo == null) {
@@ -84,10 +81,7 @@ namespace PeterO.Cbor {
 
     internal CBORObject ConvertWithConverter(object obj) {
       Object type = obj.GetType();
-      ConverterInfo convinfo = null;
-      if (this.converters.ContainsKey(type)) {
-        convinfo = this.converters[type];
-      } else {
+      if (!this.converters.TryGetValue(type, out ConverterInfo convinfo)) {
         return null;
       }
       return (convinfo == null) ? null :

--- a/CBOR/PeterO/Cbor/OptionsParser.cs
+++ b/CBOR/PeterO/Cbor/OptionsParser.cs
@@ -69,8 +69,8 @@ namespace PeterO.Cbor {
 
     public string GetLCString(string key, string defaultValue) {
       string lckey = DataUtilities.ToLowerCaseAscii(key);
-      if (this.dict.ContainsKey(lckey)) {
-        string lcvalue = DataUtilities.ToLowerCaseAscii(this.dict[lckey]);
+      if (this.dict.TryGetValue(lckey, out string val)) {
+        string lcvalue = DataUtilities.ToLowerCaseAscii(val);
         return lcvalue;
       }
       return defaultValue;
@@ -78,8 +78,8 @@ namespace PeterO.Cbor {
 
     public bool GetBoolean(string key, bool defaultValue) {
       string lckey = DataUtilities.ToLowerCaseAscii(key);
-      if (this.dict.ContainsKey(lckey)) {
-        string lcvalue = DataUtilities.ToLowerCaseAscii(this.dict[lckey]);
+      if (this.dict.TryGetValue(lckey, out string val)) {
+        string lcvalue = DataUtilities.ToLowerCaseAscii(val);
         return lcvalue.Equals("1", StringComparison.Ordinal) ||
           lcvalue.Equals("yes", StringComparison.Ordinal) ||
           lcvalue.Equals("on", StringComparison.Ordinal) ||

--- a/CBORDocs2/CBORDocs2.csproj
+++ b/CBORDocs2/CBORDocs2.csproj
@@ -10,11 +10,13 @@
     <DebugType>none</DebugType>
     <CodeAnalysisRuleSet>rules.ruleset</CodeAnalysisRuleSet></PropertyGroup>
   <ItemGroup>
-    <ProjectReference Include='..\CBORDocs\CBORDocs.csproj'/>
-  <AdditionalFiles Include='stylecop.json'/><AdditionalFiles Include='rules.ruleset'/></ItemGroup>
-      <ItemGroup>
-        <PackageReference Include='Microsoft.CodeAnalysis.NetAnalyzers' PrivateAssets='All' Version='5.0.3'/><PackageReference Include='PeterO.URIUtility' Version='1.0.0'/>
-  <PackageReference Include='PeterO.DataUtilities' Version='1.1.0'/>
-        <PackageReference Include='StyleCop.Analyzers' PrivateAssets='All' Version='1.2.0-beta.354'/>
-      </ItemGroup>
-   </Project>
+    <AdditionalFiles Include='stylecop.json'/>
+    <AdditionalFiles Include='rules.ruleset'/>
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include='Microsoft.CodeAnalysis.NetAnalyzers' PrivateAssets='All' Version='5.0.3'/>
+    <PackageReference Include='PeterO.URIUtility' Version='1.0.0'/>
+    <PackageReference Include='PeterO.DataUtilities' Version='1.1.0'/>
+    <PackageReference Include='StyleCop.Analyzers' PrivateAssets='All' Version='1.2.0-beta.354'/>
+  </ItemGroup>
+</Project>

--- a/CBORDocs2/DocVisitor.cs
+++ b/CBORDocs2/DocVisitor.cs
@@ -174,10 +174,10 @@ IsMethodOverride((MethodInfo)method)) {
   StringComparison.Ordinal)) {
           builder.Append("implicit operator ");
           builder.Append(FormatType(methodInfo.ReturnType));
-        } else if (ValueOperators.ContainsKey(method.Name)) {
+        } else if (ValueOperators.TryGetValue(method.Name, out string op)) {
           builder.Append(FormatType(methodInfo.ReturnType));
           builder.Append(" operator ");
-          builder.Append(ValueOperators[method.Name]);
+          builder.Append(op);
         } else {
           if (!shortform) {
             builder.Append(FormatType(methodInfo.ReturnType));
@@ -879,8 +879,8 @@ property.GetCustomAttribute(typeof(CLSCompliantAttribute)) as
     }
 
     private static string MethodNameHeading(string p) {
-      return ValueOperators.ContainsKey(p) ? ("Operator `" +
-        ValueOperators[p] + "`") :
+      return ValueOperators.TryGetValue(p, out string op) ? ("Operator `" +
+        op + "`") :
         (p.Equals("op_Explicit", StringComparison.Ordinal) ?
           "Explicit Operator" :
          (p.Equals("op_Implicit", StringComparison.Ordinal) ?

--- a/CBORDocs2/XmlDoc.cs
+++ b/CBORDocs2/XmlDoc.cs
@@ -48,7 +48,7 @@ namespace PeterO.DocGen {
 
       public string GetAttribute(string str) {
         return (this.attributes == null ||
-           !this.attributes.ContainsKey(str)) ? null : this.attributes[str];
+           !this.attributes.TryGetValue(str, out string attr)) ? null : attr;
       }
 
       public string GetContent() {
@@ -184,18 +184,17 @@ namespace PeterO.DocGen {
     private readonly IDictionary<string, INode> memberNodes;
 
     public INode GetMemberNode(string memberID) {
-      if (!this.memberNodes.ContainsKey(memberID)) {
+      if (!this.memberNodes.TryGetValue(memberID, out INode node)) {
         return null;
       } else {
-        return this.memberNodes[memberID];
+        return node;
       }
     }
 
     public string GetSummary(string memberID) {
-      if (!this.memberNodes.ContainsKey(memberID)) {
+      if (!this.memberNodes.TryGetValue(memberID, out INode mn)) {
         return null;
       } else {
-        var mn = this.memberNodes[memberID];
         var sb = new StringBuilder();
         foreach (var c in mn.GetChildren()) {
           if (c.LocalName.Equals("summary", StringComparison.Ordinal)) {

--- a/CBORTest/QueryStringHelper.cs
+++ b/CBORTest/QueryStringHelper.cs
@@ -332,10 +332,10 @@ namespace Test {
       int count = dict.Count;
       while (index < count) {
         string indexString = IntToString(index);
-        if (!dict.ContainsKey(indexString)) {
+        if (!dict.TryGetValue(indexString, out object o)) {
           throw new InvalidOperationException();
         }
-        ret.Add(dict[indexString]);
+        ret.Add(o);
         ++index;
       }
       return ret;
@@ -438,7 +438,7 @@ namespace Test {
         string[] path = GetKeyPath(keyvalue[0]);
         IDictionary<string, Object> leaf = root;
         for (int i = 0; i < path.Length - 1; ++i) {
-          if (!leaf.ContainsKey(path[i])) {
+          if (!leaf.TryGetValue(path[i], out object di)) {
             // node doesn't exist so add it
             IDictionary<string, Object> newLeaf = new Dictionary<string, Object>();
             if (leaf.ContainsKey(path[i])) {
@@ -447,7 +447,6 @@ namespace Test {
             leaf.Add(path[i], newLeaf);
             leaf = newLeaf;
           } else {
-            object di = leaf[path[i]];
             IDictionary<string, Object> o = di as IDictionary<string, Object>;
             if (o != null) {
               leaf = o;
@@ -458,10 +457,11 @@ namespace Test {
           }
         }
         if (leaf != null) {
-          if (leaf.ContainsKey(path[path.Length - 1])) {
+          string last = path[path.Length - 1];
+          if (leaf.ContainsKey(last)) {
             throw new InvalidOperationException();
           }
-          leaf.Add(path[path.Length - 1], keyvalue[1]);
+          leaf.Add(last, keyvalue[1]);
         }
       }
       return root;


### PR DESCRIPTION
To reduce repetitive (hash + bucket search) overhead.
Also make use of dictionary Remove() behavior that returns true on successful removal, and remove a missing project reference in CBORDocs2.