### PR TITLE
Expose FromGuid, AsGuid, and FromMap, and make AsGuid more efficient

### DIFF
--- a/CBOR/PeterO/Cbor/CBORObject.cs
+++ b/CBOR/PeterO/Cbor/CBORObject.cs
@@ -2332,6 +2332,12 @@ FromString(strValue);
           FromInt64((long)value);
     }
 
+    /// <summary>Generates a CBOR object from a Guid.</summary>
+    /// <param name='value'>The parameter <paramref name='value'/> is a
+    /// Guid.</param>
+    /// <returns>A CBOR object.</returns>
+    public static CBORObject FromGuid(Guid value) => new CBORUuidConverter().ToCBORObject(value);
+
     /// <summary>Generates a CBOR object from a 32-bit signed
     /// integer.</summary>
     /// <param name='value'>The parameter <paramref name='value'/> is a
@@ -4659,6 +4665,14 @@ throw new OverflowException() : (int)longValue;
     public float AsSingle() {
       CBORNumber cn = this.AsNumber();
       return cn.GetNumberInterface().AsSingle(cn.GetValue());
+    }
+
+    /// <summary>Converts this object to a Guid.</summary>
+    /// <returns>A Guid.</returns>
+    /// <exception cref="InvalidOperationException">This object does
+    /// not represent a Guid.</exception>
+    public Guid AsGuid() {
+      return new CBORUuidConverter().FromCBORObject(this);
     }
 
     /// <summary>Gets the value of this object as a text string.</summary>

--- a/CBOR/PeterO/Cbor/CBORObject.cs
+++ b/CBOR/PeterO/Cbor/CBORObject.cs
@@ -3236,6 +3236,20 @@ smallTag) =>
           new SortedDictionary<CBORObject, CBORObject>());
     }
 
+    /// <summary>Creates a new CBOR map that stores its keys in an
+    /// undefined order.</summary>
+    /// <param name='keysAndValues'>A sequence of key-value pairs.</param>
+    /// <returns>A new CBOR map.</returns>
+    public static CBORObject FromMap(IEnumerable<Tuple<CBORObject, CBORObject>> keysAndValues) {
+      var sd = new SortedDictionary<CBORObject, CBORObject>();
+      foreach (Tuple<CBORObject, CBORObject> kv in keysAndValues) {
+        sd.Add(kv.Item1, kv.Item2);
+      }
+      return new CBORObject(
+          CBORObjectTypeMap,
+          sd);
+    }
+
     /// <summary>Creates a new empty CBOR map that ensures that keys are
     /// stored in the order in which they are first inserted.</summary>
     /// <returns>A new CBOR map.</returns>
@@ -3243,6 +3257,20 @@ smallTag) =>
       return new CBORObject(
           CBORObjectTypeMap,
           PropertyMap.NewOrderedDict());
+    }
+
+    /// <summary>Creates a new CBOR map that ensures that keys are
+    /// stored in order.</summary>
+    /// <param name='keysAndValues'>A sequence of key-value pairs.</param>
+    /// <returns>A new CBOR map.</returns>
+    public static CBORObject FromOrderedMap(IEnumerable<Tuple<CBORObject, CBORObject>> keysAndValues) {
+      var oDict = PropertyMap.NewOrderedDict();
+      foreach (Tuple<CBORObject, CBORObject> kv in keysAndValues) {
+        oDict.Add(kv.Item1, kv.Item2);
+      }
+      return new CBORObject(
+          CBORObjectTypeMap,
+          oDict);
     }
 
     /// <summary>

--- a/CBOR/PeterO/Cbor/CBORObject.cs
+++ b/CBOR/PeterO/Cbor/CBORObject.cs
@@ -4670,7 +4670,8 @@ throw new OverflowException() : (int)longValue;
     /// <summary>Converts this object to a Guid.</summary>
     /// <returns>A Guid.</returns>
     /// <exception cref="InvalidOperationException">This object does
-    /// not represent a Guid.</exception>
+    /// not represent a Guid.</exception><exception cref="CBORException">
+    /// This object does not have the expected tag.</exception>
     public Guid AsGuid() {
       return new CBORUuidConverter().FromCBORObject(this);
     }

--- a/CBOR/PeterO/Cbor/CBORUuidConverter.cs
+++ b/CBOR/PeterO/Cbor/CBORUuidConverter.cs
@@ -34,19 +34,9 @@ namespace PeterO.Cbor {
         throw new CBORException("Must have outermost tag 37");
       }
       _ = ValidateObject(obj);
-      byte[] bytes = obj.GetByteString();
-      var guidChars = new char[36];
-      string hex = "0123456789abcdef";
-      var index = 0;
-      for (int i = 0; i < 16; ++i) {
-        if (i == 4 || i == 6 || i == 8 || i == 10) {
-          guidChars[index++] = '-';
-        }
-        guidChars[index++] = hex[(bytes[i] >> 4) & 15];
-        guidChars[index++] = hex[bytes[i] & 15];
-      }
-      var guidString = new String(guidChars);
-      return new Guid(guidString);
+      byte[] b2 = obj.GetByteString();
+      byte[] bytes = { b2[3], b2[2], b2[1], b2[0], b2[5], b2[4], b2[7], b2[6], b2[8], b2[9], b2[10], b2[11], b2[12], b2[13], b2[14], b2[15] };
+      return new Guid(bytes);
     }
   }
 }


### PR DESCRIPTION
- Expose `FromGuid` and `AsGuid`. Currently this must be done via `FromObject(object value)` and `ToObject<Guid>`, resulting in type tests and trimming incompatibility in each case.
- Expose `FromMap` and `FromOrderedMap` to be able to create Maps cleanly without use of Add on `CBORObject` (which is not type-safe and is trimming-incompatible).
- Make `CBORObject -> Guid` more efficient by avoiding a string conversion