### PR TITLE
use correct framework

### DIFF
--- a/CBORDocs2/CBORDocs2.csproj
+++ b/CBORDocs2/CBORDocs2.csproj
@@ -1,6 +1,6 @@
 <Project Sdk='Microsoft.NET.Sdk'>
   <PropertyGroup>
-    <TargetFramework>netcoreapp6.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <!--<GenerateProgramFile>false</GenerateProgramFile>-->
   </PropertyGroup>
   <PropertyGroup Condition=' &apos;$(Configuration)&apos;==&apos;Debug&apos; '>

--- a/CBORTest/CBORTest.csproj
+++ b/CBORTest/CBORTest.csproj
@@ -1,6 +1,6 @@
 <Project Sdk='Microsoft.NET.Sdk'>
   <PropertyGroup>
-    <TargetFramework>netcoreapp8.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
   <PropertyGroup Condition=' &apos;$(Configuration)&apos;==&apos;Debug&apos; '>
     <DebugType>full</DebugType>


### PR DESCRIPTION
the undocumented names (without period in dotnet 5+) can drop their support when move to double-digit (to avoid potential conflicts) https://learn.microsoft.com/en-us/dotnet/standard/frameworks#supported-target-frameworks